### PR TITLE
fix: ignore coverage in tsc build script

### DIFF
--- a/banhmi/tsconfig.json
+++ b/banhmi/tsconfig.json
@@ -22,5 +22,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["typings.d.ts", "./src/**/*"],
-  "exclude": ["./dist", "./node_modules"]
+  "exclude": ["./dist", "./node_modules", "./src/coverage"]
 }


### PR DESCRIPTION
# Description

Fix the TypeScript build error that does not exclude coverage directory.

<img width="718" alt="image" src="https://user-images.githubusercontent.com/115213709/196722105-c0f3853c-5dd0-4269-8176-577578128774.png">
