### PR TITLE
fix: check if auth header is undefined

### DIFF
--- a/banhmi/src/middlewares/auth.ts
+++ b/banhmi/src/middlewares/auth.ts
@@ -4,6 +4,13 @@ import { prisma } from '@/db';
 
 const authenticate = async function (req: Request, res, next) {
   const accessToken = req.headers.authorization?.split(' ')[1];
+
+  if (typeof accessToken === 'undefined') {
+    return res.status(403).json({
+      error: 'Unauthorized',
+    });
+  }
+
   const token = await prisma.authToken.findFirst({
     where: {
       accessToken: accessToken,

--- a/banhmi/src/middlewares/auth.ts
+++ b/banhmi/src/middlewares/auth.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import createHttpError from 'http-errors';
 
 import { prisma } from '@/db';
 
@@ -6,9 +7,7 @@ const authenticate = async function (req: Request, res, next) {
   const accessToken = req.headers.authorization?.split(' ')[1];
 
   if (typeof accessToken === 'undefined') {
-    return res.status(403).json({
-      error: 'Unauthorized',
-    });
+    return next(createHttpError(403, 'Unauthorized'));
   }
 
   const token = await prisma.authToken.findFirst({
@@ -18,17 +17,14 @@ const authenticate = async function (req: Request, res, next) {
   });
 
   // check if token is not null
-  if (token === null)
-    return res.status(403).json({
-      error: 'Unauthorized',
-    });
+  if (token === null) {
+    return next(createHttpError(403, 'Unauthorized'));
+  }
 
   // check if accessToken expired
-  if (token.expiredTime < new Date())
-    return res.status(403).json({
-      error: 'Unauthorized',
-    });
-
+  if (token.expiredTime < new Date()) {
+    return next(createHttpError(403, 'Unauthorized'));
+  }
   // get user profile
   const user = await prisma.user.findFirst({
     where: {

--- a/banhmi/src/middlewares/auth.ts
+++ b/banhmi/src/middlewares/auth.ts
@@ -7,7 +7,7 @@ const authenticate = async function (req: Request, res, next) {
   const accessToken = req.headers.authorization?.split(' ')[1];
 
   if (typeof accessToken === 'undefined') {
-    return next(createHttpError(403, 'Unauthorized'));
+    return next(createHttpError(401, 'Unauthorized'));
   }
 
   const token = await prisma.authToken.findFirst({
@@ -18,12 +18,12 @@ const authenticate = async function (req: Request, res, next) {
 
   // check if token is not null
   if (token === null) {
-    return next(createHttpError(403, 'Unauthorized'));
+    return next(createHttpError(401, 'Unauthorized'));
   }
 
   // check if accessToken expired
   if (token.expiredTime < new Date()) {
-    return next(createHttpError(403, 'Unauthorized'));
+    return next(createHttpError(401, 'Unauthorized'));
   }
   // get user profile
   const user = await prisma.user.findFirst({


### PR DESCRIPTION
# Description

If authorization header does not exist in the request, `accessToken` would be undefined, and `prisma.findFirst()` does not throw any error. Therefore, we should handle this case separately.