### PR TITLE
fix: handle access token invalid

### DIFF
--- a/pho/src/lib/apis/user.ts
+++ b/pho/src/lib/apis/user.ts
@@ -32,16 +32,19 @@ export const updateUserSpaceId = async (spaceId: number | null) => {
   if (!accessToken) {
     return;
   }
-
-  await axios.patch(
-    `${config.endpoint.banhmi}/api/users`,
-    {
-      spaceId,
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
+  try {
+    await axios.patch(
+      `${config.endpoint.banhmi}/api/users`,
+      {
+        spaceId,
       },
-    }
-  );
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+  } catch (err) {
+    console.log(err);
+  }
 };


### PR DESCRIPTION
# Description

Handle case when access token is invalid (the request is still sent to the server but the response is unauthorized)